### PR TITLE
Init flashWriter to NULL.

### DIFF
--- a/flash.h
+++ b/flash.h
@@ -96,7 +96,7 @@ private:
     byte *FAT;
     byte *rootBlock;
     byte *data;
-    FILE *flashWriter;
+    FILE *flashWriter = NULL;
     char *romName;
     bool IsRealFlash;
     bool IsSaveEnabled;


### PR DESCRIPTION
This fixes a segfault when loaded without content.

When vemulator is loaded without content.
```
retroarch -L /path/to/vemulator_libretro.so
```
It will crash when the following conditional is true, but since no content was started it should not be...

https://github.com/MJaoune/vemulator-libretro/blob/78d09078c117e1e023842ed6d49fdc8d76eec37f/flash.cpp#L37

Also see this PR that discusses similar issues for other libretro cores.

https://github.com/libretro/RetroArch/pull/7102